### PR TITLE
Update modalities

### DIFF
--- a/instances/modality/anatomicalApproach.jsonld
+++ b/instances/modality/anatomicalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/anatomicalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/anatomicalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "anatomical approach",
-  "definition": null,
+  "definition": "Techniques concerned with the bodily structure of living organisms, especially as revealed by dissection and the separation of parts.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739411"
 }

--- a/instances/modality/behavioralApproach.jsonld
+++ b/instances/modality/behavioralApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/behavioralApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/behavioralApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "behavioral approach",
-  "definition": null,
+  "definition": "Techniques concerned with determining cognitive powers of living organisms and/or their responses to stimuli.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739413"
 }

--- a/instances/modality/cellMorphology.jsonld
+++ b/instances/modality/cellMorphology.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/cellMorphology",
+  "@id": "https://openminds.ebrains.eu/instances/modality/cellMorphology",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "cell morphology",
-  "definition": null,
+  "definition": "Techniques concerned with determining the shape and structure of individual cells.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739394"
 }

--- a/instances/modality/cellPopulationCharacterization.jsonld
+++ b/instances/modality/cellPopulationCharacterization.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/cellPopulationCharacterization",
+  "@id": "https://openminds.ebrains.eu/instances/modality/cellPopulationCharacterization",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "cell population characterization",
-  "definition": null,
+  "definition": "Techniques concerned with determining biochemical, molecular and/or physiological characteristics of cell populations as opposed to individual cells.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739408"
 }

--- a/instances/modality/cellPopulationImaging.jsonld
+++ b/instances/modality/cellPopulationImaging.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/cellPopulationImaging",
+  "@id": "https://openminds.ebrains.eu/instances/modality/cellPopulationImaging",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "cell population imaging",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739402"
 }

--- a/instances/modality/cellPopulationManipulation.jsonld
+++ b/instances/modality/cellPopulationManipulation.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/cellPopulationManipulation",
+  "@id": "https://openminds.ebrains.eu/instances/modality/cellPopulationManipulation",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "cell population manipulation",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739398"
 }

--- a/instances/modality/cellularApproach.jsonld
+++ b/instances/modality/cellularApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/cellularApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/cellularApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "cellular approach",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739391"
 }

--- a/instances/modality/clinicalApproach.jsonld
+++ b/instances/modality/clinicalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/clinicalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/clinicalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "clinical approach",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739401"
 }

--- a/instances/modality/computationalModeling.jsonld
+++ b/instances/modality/computationalModeling.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/computationalModeling",
+  "@id": "https://openminds.ebrains.eu/instances/modality/computationalModeling",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "computational modeling",
-  "definition": null,
+  "definition": "Techniques concerned with creating or characterizing computational models or simulations of other experimentally observed phenomena.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739414"
 }

--- a/instances/modality/developmentalApproach.jsonld
+++ b/instances/modality/developmentalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/developmentalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/developmentalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "developmental approach",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739412"
 }

--- a/instances/modality/ecologicalApproach.jsonld
+++ b/instances/modality/ecologicalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/ecologicalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/ecologicalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "ecological approach",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739389"
 }

--- a/instances/modality/electrophysiology.jsonld
+++ b/instances/modality/electrophysiology.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/electrophysiology",
+  "@id": "https://openminds.ebrains.eu/instances/modality/electrophysiology",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "electrophysiology",
-  "definition": null,
+  "definition": "Techniques concerned with the electrical phenomena associated with neural and other bodily activity.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0741202"
 }

--- a/instances/modality/epidemiologicalApproach.jsonld
+++ b/instances/modality/epidemiologicalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/epidemiologicalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/epidemiologicalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "epidemiological approach",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739400"
 }

--- a/instances/modality/epigenomics.jsonld
+++ b/instances/modality/epigenomics.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/epigenomics",
+  "@id": "https://openminds.ebrains.eu/instances/modality/epigenomics",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "epigenomics",
-  "definition": null,
+  "definition": "Techniques concerned with determining genetic modifications that affect transcription but do not alter the organism's DNA.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0741207"
 }

--- a/instances/modality/ethologicalApproach.jsonld
+++ b/instances/modality/ethologicalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/ethologicalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/ethologicalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "ethological approach",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739388"
 }

--- a/instances/modality/evolutionaryApproach.jsonld
+++ b/instances/modality/evolutionaryApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/evolutionaryApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/evolutionaryApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "evolutionary approach",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739392"
 }

--- a/instances/modality/expressionCharacterization.jsonld
+++ b/instances/modality/expressionCharacterization.jsonld
@@ -1,0 +1,8 @@
+{
+  "@id": "https://openminds.ebrains.eu/instances/modality/expressionCharacterization",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
+  "name": "expression characterization",
+  "definition": "Techniques concerned with determining the cellular, anatomical, or morphological distribution of gene expression.",
+  "description": null,
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739409"
+}

--- a/instances/modality/genomics.jsonld
+++ b/instances/modality/genomics.jsonld
@@ -1,0 +1,8 @@
+{
+  "@id": "https://openminds.ebrains.eu/instances/modality/genomics",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
+  "name": "genomics",
+  "definition": "Techniques concerned with the structure, function, evolution, and mapping of genomes.",
+  "description": null,
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0741204"
+}

--- a/instances/modality/histologicalApproach.jsonld
+++ b/instances/modality/histologicalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/histologicalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/histologicalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "histological approach",
-  "definition": null,
+  "definition": "Techniques concerned with the microscopic anatomy of biological tissue.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739399"
 }

--- a/instances/modality/metabolomics.jsonld
+++ b/instances/modality/metabolomics.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/metabolomics",
+  "@id": "https://openminds.ebrains.eu/instances/modality/metabolomics",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "metabolomics",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0741203"
 }

--- a/instances/modality/microscopy.jsonld
+++ b/instances/modality/microscopy.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/microscopy",
+  "@id": "https://openminds.ebrains.eu/instances/modality/microscopy",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "microscopy",
-  "definition": null,
+  "definition": "Techniques using microscopes to view objects and areas of objects that cannot be seen with the naked eye.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739404"
 }

--- a/instances/modality/molecularExpressionApproach.jsonld
+++ b/instances/modality/molecularExpressionApproach.jsonld
@@ -1,0 +1,8 @@
+{
+  "@id": "https://openminds.ebrains.eu/instances/modality/molecularExpressionApproach",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
+  "name": "molecular expression approach",
+  "definition": "Techniques concerned with determining single gene or protein expression within cells or tissues.",
+  "description": null,
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739397"
+}

--- a/instances/modality/morphologialApproach.jsonld
+++ b/instances/modality/morphologialApproach.jsonld
@@ -1,0 +1,8 @@
+{
+  "@id": "https://openminds.ebrains.eu/instances/modality/morphologialApproach",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
+  "name": "morphologial approach",
+  "definition": "Techniques concerned with the form and structure of living organisms or biological tissue.",
+  "description": null,
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739403"
+}

--- a/instances/modality/multimodalApproach.jsonld
+++ b/instances/modality/multimodalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/multimodalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/multimodalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "multimodal approach",
-  "definition": null,
+  "definition": "Techniques that employ multiple modalities in significant ways.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739395"
 }

--- a/instances/modality/multiomics.jsonld
+++ b/instances/modality/multiomics.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/multiomics",
+  "@id": "https://openminds.ebrains.eu/instances/modality/multiomics",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "multiomics",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739407"
 }

--- a/instances/modality/neuralConnectivity.jsonld
+++ b/instances/modality/neuralConnectivity.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/neuralConnectivity",
+  "@id": "https://openminds.ebrains.eu/instances/modality/neuralConnectivity",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "neural connectivity",
-  "definition": null,
+  "definition": "Techniques concerned with determining functional and/or anatomical connections between single neurons or neuron populations in defined anatomical regions.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739393"
 }

--- a/instances/modality/neuroimaging.jsonld
+++ b/instances/modality/neuroimaging.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/neuroimaging",
+  "@id": "https://openminds.ebrains.eu/instances/modality/neuroimaging",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "neuroimaging",
-  "definition": null,
+  "definition": "Techniques concerned with imaging directly or indirectly the structure, function, or pharmacology of the nervous system.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0741206"
 }

--- a/instances/modality/omics.jsonld
+++ b/instances/modality/omics.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/omics",
+  "@id": "https://openminds.ebrains.eu/instances/modality/omics",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "omics",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739405"
 }

--- a/instances/modality/physiologicalApproach.jsonld
+++ b/instances/modality/physiologicalApproach.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/physiologicalApproach",
+  "@id": "https://openminds.ebrains.eu/instances/modality/physiologicalApproach",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "physiological approach",
-  "definition": null,
+  "definition": "Techniques concerned with determining normal functions of living organisms and their parts.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739410"
 }

--- a/instances/modality/proteomics.jsonld
+++ b/instances/modality/proteomics.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/proteomics",
+  "@id": "https://openminds.ebrains.eu/instances/modality/proteomics",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "proteomics",
   "definition": null,
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0741205"
 }

--- a/instances/modality/radiology.jsonld
+++ b/instances/modality/radiology.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/radiology",
+  "@id": "https://openminds.ebrains.eu/instances/modality/radiology",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "radiology",
-  "definition": null,
+  "definition": "Techniques concerned with the use of radiant energy or radioactive material in the diagnosis and treatment of disease.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739390"
 }

--- a/instances/modality/spatialTranscriptomics.jsonld
+++ b/instances/modality/spatialTranscriptomics.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/spatialTranscriptomics",
+  "@id": "https://openminds.ebrains.eu/instances/modality/spatialTranscriptomics",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "spatial transcriptomics",
-  "definition": null,
+  "definition": "Techniques concerned with determining and mapping all gene activity in biological tissue.",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739396"
 }

--- a/instances/modality/transcriptomics.jsonld
+++ b/instances/modality/transcriptomics.jsonld
@@ -1,8 +1,8 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/modality/transcriptomics",
+  "@id": "https://openminds.ebrains.eu/instances/modality/transcriptomics",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Modality",
   "name": "transcriptomics",
-  "definition": null,
+  "definition": "Techniques concerned with determining an organism's transcriptome (all RNA transcripts).",
   "description": null,
-  "ontologyIdentifier": null
+  "ontologyIdentifier": "http://uri.interlex.org/base/ilx_0739406"
 }


### PR DESCRIPTION
- added missing modalities compared to ontology list

Changes within the schemas:
- changed at_id from "https://openminds.ebrains.eu/controlledTerms/modality/modalityName" to "https://openminds.ebrains.eu/instances/modality/modalityName" 
- added definition fom ontology when available
- added ontology identifier to all modalities

related to https://github.com/HumanBrainProject/openMINDS_controlledTerms/issues/35