### PR TITLE
remove digitalidentifierschemas due to change of concept

### DIFF
--- a/instances/digitalIdentifierSchema/crossrefFunderID.jsonld
+++ b/instances/digitalIdentifierSchema/crossrefFunderID.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/crossrefFunderID",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "Crossref Funder ID",
-  "IRI": "https://www.crossref.org/services/funder-registry/",
-  "identifierPattern": null
-}

--- a/instances/digitalIdentifierSchema/doi.jsonld
+++ b/instances/digitalIdentifierSchema/doi.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/doi",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "DOI",
-  "IRI": "https://www.doi.org",
-  "identifierPattern": "https://doi.org/.*?/.*?"
-}

--- a/instances/digitalIdentifierSchema/grid.jsonld
+++ b/instances/digitalIdentifierSchema/grid.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/grid",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "GRID",
-  "IRI": "https://www.grid.ac/",
-  "identifierPattern": null
-}

--- a/instances/digitalIdentifierSchema/isni.jsonld
+++ b/instances/digitalIdentifierSchema/isni.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/isni",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "ISNI",
-  "IRI": "https://isni.org/",
-  "identifierPattern": null
-}

--- a/instances/digitalIdentifierSchema/orcid.jsonld
+++ b/instances/digitalIdentifierSchema/orcid.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/orcid",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "ORCID",
-  "IRI": "https://orcid.org/",
-  "identifierPattern": "https:\/\/orcid.org\/\d{4}-\d{4}-\d{4}-(\d{3}X|\d{4})$"
-}

--- a/instances/digitalIdentifierSchema/ror.jsonld
+++ b/instances/digitalIdentifierSchema/ror.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/ror",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "ROR",
-  "IRI": "https://ror.org/",
-  "identifierPattern": null
-}

--- a/instances/digitalIdentifierSchema/rrid.jsonld
+++ b/instances/digitalIdentifierSchema/rrid.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/rrid",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "RRID",
-  "IRI": "https://scicrunch.org/resources",
-  "identifierPattern": null
-}

--- a/instances/digitalIdentifierSchema/wikidata.jsonld
+++ b/instances/digitalIdentifierSchema/wikidata.jsonld
@@ -1,7 +1,0 @@
-{
-  "@id": "https://openminds.ebrains.eu/instances/digitalIdentifierSchema/wikidata",
-  "@type": "https://openminds.ebrains.eu/core/DigitalIdentifierSchema",
-  "type": "wikidata",
-  "IRI": "https://www.wikidata.org",
-  "identifierPattern": null
-}


### PR DESCRIPTION
now, the digital identifiers are strongly typed - therefore, there is no need for digital identifier schemas anymore...