### PR TITLE
Create embryonicDay.jsonld

### DIFF
--- a/instances/unitOfMeasurement/embryonicDay.jsonld
+++ b/instances/unitOfMeasurement/embryonicDay.jsonld
@@ -1,0 +1,8 @@
+{
+  "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/embryonicDay",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UnitOfMeasurement",
+  "name": "embryonic day",
+  "definition": "'Embryonic day' is a specific unit to measure the time pasted since fertilization of an egg cell.",
+  "description": null,
+  "ontologyIdentifier": null
+}

--- a/instances/unitOfMeasurement/embryonicDay.jsonld
+++ b/instances/unitOfMeasurement/embryonicDay.jsonld
@@ -2,7 +2,7 @@
   "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/embryonicDay",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UnitOfMeasurement",
   "name": "embryonic day",
-  "definition": "'Embryonic day' is a specific unit to measure the time pasted since fertilization of an egg cell.",
+  "definition": "'Embryonic day' is a specific unit to measure the developmental stage of an embryo, starting with fertilization (1st embryonic day).",  
   "description": null,
   "ontologyIdentifier": null
 }


### PR DESCRIPTION
For subject ages, it will be useful to not only measure from the date of birth but rather also from the date of fertilization. The reason is that pregnancy durations can vary (e.g. mice are pregnant 18 - 21 days) which will make it difficult to simply use negative values to express these ages. Additionally, embryonic days are quite commonly used in the community :) 
