### PR TITLE
Cell cluture

### DIFF
--- a/instances/tissueSampleType/cellCulture.jsonld
+++ b/instances/tissueSampleType/cellCulture.jsonld
@@ -2,7 +2,7 @@
     "@id": "https://openminds.ebrains.eu/instances/tissueSampleType/cellCulture",
     "@type": "https://openminds.ebrains.eu/controlledTerms/TissueSampleType",
     "name": "cell culture",
-    "definition": null,
+    "definition": "Cells taken from a living organism and grown under controlled conditions (in culture).",
     "description": null,
-    "ontologyIdentifier": null
+    "ontologyIdentifier": "http://purl.obolibrary.org/obo/BTO_0000214"
 }

--- a/instances/tissueSampleType/cellCulture.jsonld
+++ b/instances/tissueSampleType/cellCulture.jsonld
@@ -1,0 +1,8 @@
+{
+    "@id": "https://openminds.ebrains.eu/instances/tissueSampleType/cellCulture",
+    "@type": "https://openminds.ebrains.eu/controlledTerms/TissueSampleType",
+    "name": "cell culture",
+    "definition": null,
+    "description": null,
+    "ontologyIdentifier": null
+}


### PR DESCRIPTION
Adding `cellCulture` as instance to `tissueSampleType`. 
This is needed as the [openMINDS/ephys](https://github.com/HumanBrainProject/openMINDS_ephys) uses the `tissueSampleSate` to represent a cell culture grown in the lab and needs to distinguish it from other types of the tissue sample.  