### PR TITLE
Preparation type updates

### DIFF
--- a/instances/preparationType/exVivo.jsonld
+++ b/instances/preparationType/exVivo.jsonld
@@ -6,11 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening or existing outside a living body.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/ilx_0781256",
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0739736",
   "knowledgeSpaceLink": null,
   "name": "ex vivo",
-  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001211",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/indexes/ontologies/methods/88",
   "synonym": [
-    "ex vivo design"
+    "ex vivo technique"
   ]
 }

--- a/instances/preparationType/exVivo.jsonld
+++ b/instances/preparationType/exVivo.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening or existing outside a living body.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0781256",
   "knowledgeSpaceLink": null,
   "name": "ex vivo",
-  "preferredOntologyIdentifier": null,
-  "synonym": null
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001211",
+  "synonym": [
+    "ex vivo design"
+  ]
 }

--- a/instances/preparationType/inSilico.jsonld
+++ b/instances/preparationType/inSilico.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Conducted or produced by means of computer modelling or simulation.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0494742",
   "knowledgeSpaceLink": null,
   "name": "in silico",
   "preferredOntologyIdentifier": null,

--- a/instances/preparationType/inSilico.jsonld
+++ b/instances/preparationType/inSilico.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/ilx_0494742",
   "knowledgeSpaceLink": null,
   "name": "in silico",
-  "preferredOntologyIdentifier": null,
+  "preferredOntologyIdentifier": "http://id.nlm.nih.gov/mesh/2018/M0572590",
   "synonym": null
 }

--- a/instances/preparationType/inSitu.jsonld
+++ b/instances/preparationType/inSitu.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/ilx_0739593",
   "knowledgeSpaceLink": null,
   "name": "in situ",
-  "preferredOntologyIdentifier": null,
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/technique/inSitu",
   "synonym": [
     "in situ technique"
   ]

--- a/instances/preparationType/inSitu.jsonld
+++ b/instances/preparationType/inSitu.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening or being examined in the original place instead of being moved to another place",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0739593",
   "knowledgeSpaceLink": null,
   "name": "in situ",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": [
+    "in situ technique"
+  ]
 }

--- a/instances/preparationType/inUtero.jsonld
+++ b/instances/preparationType/inUtero.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/ilx_0739675",
   "knowledgeSpaceLink": null,
   "name": "in utero",
-  "preferredOntologyIdentifier": null,
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/indexes/ontologies/methods/90",
   "synonym": [
     "in utero technique"
   ]

--- a/instances/preparationType/inUtero.jsonld
+++ b/instances/preparationType/inUtero.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening in, within, or while inside the uterus.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0739675",
   "knowledgeSpaceLink": null,
   "name": "in utero",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": [
+    "in utero technique"
+  ]
 }

--- a/instances/preparationType/inVitro.jsonld
+++ b/instances/preparationType/inVitro.jsonld
@@ -6,11 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening outside the body in artificial conditions, often in a test tube.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/ilx_0782779",
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0739568",
   "knowledgeSpaceLink": null,
   "name": "in vitro",
-  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001285",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/technique/inVitro",
   "synonym": [
-    "in vitro design"
+    "in vitro technique"
   ]
 }

--- a/instances/preparationType/inVitro.jsonld
+++ b/instances/preparationType/inVitro.jsonld
@@ -6,9 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening outside the body in artificial conditions, often in a test tube.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0782779",
   "knowledgeSpaceLink": null,
   "name": "in vitro",
-  "preferredOntologyIdentifier": null,
-  "synonym": null
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001285",
+  "synonym": ["in vitro design"]
 }

--- a/instances/preparationType/inVitro.jsonld
+++ b/instances/preparationType/inVitro.jsonld
@@ -10,5 +10,7 @@
   "knowledgeSpaceLink": null,
   "name": "in vitro",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001285",
-  "synonym": ["in vitro design"]
+  "synonym": [
+    "in vitro design"
+  ]
 }

--- a/instances/preparationType/inVivo.jsonld
+++ b/instances/preparationType/inVivo.jsonld
@@ -6,9 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening or existing inside a living body.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/ilx_0739622",
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0784018",
   "knowledgeSpaceLink": null,
   "name": "in vivo",
-  "preferredOntologyIdentifier": null,
-  "synonym": ["in vivo technique"]
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001199",
+  "synonym": ["in vivo design"]
 }

--- a/instances/preparationType/inVivo.jsonld
+++ b/instances/preparationType/inVivo.jsonld
@@ -6,9 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening or existing inside a living body.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0739622",
   "knowledgeSpaceLink": null,
   "name": "in vivo",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": ["in vivo technique"]
 }

--- a/instances/preparationType/inVivo.jsonld
+++ b/instances/preparationType/inVivo.jsonld
@@ -10,5 +10,7 @@
   "knowledgeSpaceLink": null,
   "name": "in vivo",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001199",
-  "synonym": ["in vivo design"]
+  "synonym": [
+    "in vivo design"
+  ]
 }

--- a/instances/preparationType/inVivo.jsonld
+++ b/instances/preparationType/inVivo.jsonld
@@ -6,11 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/PreparationType",
   "definition": "Something happening or existing inside a living body.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/ilx_0784018",
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0739622",
   "knowledgeSpaceLink": null,
   "name": "in vivo",
-  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/OBI_0001199",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/indexes/ontologies/methods/89",
   "synonym": [
-    "in vivo design"
+    "in vivo technique"
   ]
 }


### PR DESCRIPTION
All preparation types have an InterLex ID now. It's slightly inconsistent which is why I want @lzehl and/or @tgbugs to approve/disapprove before merging it. 
When available, I used "<<type>> design" entries because those have definitions and seems to fit better. If they where not available, I use "<<type>> technique" entry instead. Accordingly, they received the InterLex entry name as synonym as well. 

our name --> InterLex name+synonym (comment)
ex vivo --> ex vivo design (but technique exists too: http://uri.interlex.org/ilx_0739736) 
in silico --> in silico (neither "design", nor "technique" in the name) 
in situ --> in situ technique
in utero --> in utero technique  
in vitro --> in vitro design (but technique exists too: http://uri.interlex.org/ilx_0739568) 
in vivo --> in vivo design (but technique exists too: http://uri.interlex.org/ilx_0739622)

What do you think? Do we rather have a mix of "technique" & "design" entries (and be inconsistent) or stick to "technique" only (and lose the definitions/better fitting entries)? 
If we go for the mix, do we want to add "<<type>> technique" as synonyms too? 