### PR TITLE
ExpApproach updates

### DIFF
--- a/instances/experimentalApproach/anatomy.jsonld
+++ b/instances/experimentalApproach/anatomy.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739411",
   "knowledgeSpaceLink": null,
   "name": "anatomy",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739411",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Anatomy",
   "synonym": [
     "anatomical approach"
   ]

--- a/instances/experimentalApproach/anatomy.jsonld
+++ b/instances/experimentalApproach/anatomy.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the bodily structure of living organisms.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739411",
   "knowledgeSpaceLink": null,
   "name": "anatomy",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739411",
-  "synonym": null
+  "synonym": [
+    "anatomical approach"
+  ]
 }

--- a/instances/experimentalApproach/behavior.jsonld
+++ b/instances/experimentalApproach/behavior.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739413",
   "knowledgeSpaceLink": null,
   "name": "behavior",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739413",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Behavior",
   "synonym": [
     "behavioral approach"
   ]

--- a/instances/experimentalApproach/behavior.jsonld
+++ b/instances/experimentalApproach/behavior.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the mechanical activity or cognitive processes underlying mechanical activity of living organisms often in response to external sensory stimuli.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739413",
   "knowledgeSpaceLink": null,
   "name": "behavior",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739413",
-  "synonym": null
+  "synonym": [
+    "behavioral approach"
+  ]
 }

--- a/instances/experimentalApproach/cellBiology.jsonld
+++ b/instances/experimentalApproach/cellBiology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739391",
   "knowledgeSpaceLink": null,
   "name": "cell biology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739391",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Cellular",
   "synonym": [
     "cellular approach"
   ]

--- a/instances/experimentalApproach/cellBiology.jsonld
+++ b/instances/experimentalApproach/cellBiology.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on structure, function, multiplication, pathology, and life history of biological cells.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739391",
   "knowledgeSpaceLink": null,
   "name": "cell biology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739391",
-  "synonym": null
+  "synonym": [
+    "cellular approach"
+  ]
 }

--- a/instances/experimentalApproach/cellMorphology.jsonld
+++ b/instances/experimentalApproach/cellMorphology.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739394",
   "knowledgeSpaceLink": null,
   "name": "cell morphology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739394",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/CellMorphology",
   "synonym": null
 }

--- a/instances/experimentalApproach/cellMorphology.jsonld
+++ b/instances/experimentalApproach/cellMorphology.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the shape and structure of individual cells.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739394",
   "knowledgeSpaceLink": null,
   "name": "cell morphology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739394",

--- a/instances/experimentalApproach/cellPopulationCharacterization.jsonld
+++ b/instances/experimentalApproach/cellPopulationCharacterization.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on biochemical, molecular and/or physiological characteristics of populations of cells as opposed to individual cells.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739408",
   "knowledgeSpaceLink": null,
   "name": "cell population characterization",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739408",

--- a/instances/experimentalApproach/cellPopulationCharacterization.jsonld
+++ b/instances/experimentalApproach/cellPopulationCharacterization.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739408",
   "knowledgeSpaceLink": null,
   "name": "cell population characterization",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739408",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/CellPopulationCharachterization",
   "synonym": null
 }

--- a/instances/experimentalApproach/cellPopulationImaging.jsonld
+++ b/instances/experimentalApproach/cellPopulationImaging.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on imaging biochemical, molecular, or physiological characteristics of populations of cells.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739402",
   "knowledgeSpaceLink": null,
   "name": "cell population imaging",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739402",

--- a/instances/experimentalApproach/cellPopulationImaging.jsonld
+++ b/instances/experimentalApproach/cellPopulationImaging.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739402",
   "knowledgeSpaceLink": null,
   "name": "cell population imaging",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739402",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/CellPopulationImaging",
   "synonym": null
 }

--- a/instances/experimentalApproach/cellPopulationManipulation.jsonld
+++ b/instances/experimentalApproach/cellPopulationManipulation.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on manipulation of biochemical, molecular, or physiological characteristics of populations of cells.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739398",
   "knowledgeSpaceLink": null,
   "name": "cell population manipulation",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739398",

--- a/instances/experimentalApproach/cellPopulationManipulation.jsonld
+++ b/instances/experimentalApproach/cellPopulationManipulation.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739398",
   "knowledgeSpaceLink": null,
   "name": "cell population manipulation",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739398",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/CellPopulationManipulation",
   "synonym": null
 }

--- a/instances/experimentalApproach/clinicalResearch.jsonld
+++ b/instances/experimentalApproach/clinicalResearch.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739401",
   "knowledgeSpaceLink": null,
   "name": "clinical research",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739401",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Clinical",
   "synonym": [
     "clinical approach"
   ]

--- a/instances/experimentalApproach/clinicalResearch.jsonld
+++ b/instances/experimentalApproach/clinicalResearch.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on medical observation, treatment, or testing of patients.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739401",
   "knowledgeSpaceLink": null,
   "name": "clinical research",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739401",
-  "synonym": null
+  "synonym": [
+    "clinical approach"
+  ]
 }

--- a/instances/experimentalApproach/computationalModeling.jsonld
+++ b/instances/experimentalApproach/computationalModeling.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on creating or characterizing computational models or simulations of experimentally observed phenomena.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739414",
   "knowledgeSpaceLink": null,
   "name": "computational modeling",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739414",

--- a/instances/experimentalApproach/computationalModeling.jsonld
+++ b/instances/experimentalApproach/computationalModeling.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739414",
   "knowledgeSpaceLink": null,
   "name": "computational modeling",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739414",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/ComputationalModelling",
   "synonym": null
 }

--- a/instances/experimentalApproach/developmentalBiology.jsonld
+++ b/instances/experimentalApproach/developmentalBiology.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on life cycle, development, or developmental history of an organism.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739412",
   "knowledgeSpaceLink": null,
   "name": "developmental biology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739412",
-  "synonym": null
+  "synonym": [
+    "developmental approach"
+  ]
 }

--- a/instances/experimentalApproach/developmentalBiology.jsonld
+++ b/instances/experimentalApproach/developmentalBiology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739412",
   "knowledgeSpaceLink": null,
   "name": "developmental biology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739412",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Developmental",
   "synonym": [
     "developmental approach"
   ]

--- a/instances/experimentalApproach/ecology.jsonld
+++ b/instances/experimentalApproach/ecology.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on interrelationship of organisms and their environments, including causes and consequences.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739389",
   "knowledgeSpaceLink": null,
   "name": "ecology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739389",
-  "synonym": null
+  "synonym": [
+    "ecological approach"
+  ]
 }

--- a/instances/experimentalApproach/ecology.jsonld
+++ b/instances/experimentalApproach/ecology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739389",
   "knowledgeSpaceLink": null,
   "name": "ecology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739389",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Ecology",
   "synonym": [
     "ecological approach"
   ]

--- a/instances/experimentalApproach/electrophysiology.jsonld
+++ b/instances/experimentalApproach/electrophysiology.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741202",
   "knowledgeSpaceLink": null,
   "name": "electrophysiology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741202",
+  "preferredOntologyIdentifier": "	http://uri.interlex.org/tgbugs/uris/readable/modality/Electrophysiology",
   "synonym": null
 }

--- a/instances/experimentalApproach/electrophysiology.jsonld
+++ b/instances/experimentalApproach/electrophysiology.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on electrical phenomena associated with living systems, most notably the nervous system, cardiac system, and musculoskeletal system.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741202",
   "knowledgeSpaceLink": null,
   "name": "electrophysiology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741202",

--- a/instances/experimentalApproach/electrophysiology.jsonld
+++ b/instances/experimentalApproach/electrophysiology.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741202",
   "knowledgeSpaceLink": null,
   "name": "electrophysiology",
-  "preferredOntologyIdentifier": "	http://uri.interlex.org/tgbugs/uris/readable/modality/Electrophysiology",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Electrophysiology",
   "synonym": null
 }

--- a/instances/experimentalApproach/epidemiology.jsonld
+++ b/instances/experimentalApproach/epidemiology.jsonld
@@ -6,9 +6,10 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on incidence, distribution, and possible control of diseases and other factors relating to health.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739400",
   "knowledgeSpaceLink": null,
   "name": "epidemiology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739400",
-  "synonym": null
+  "synonym": [
+    "epidemiological approach"]
 }

--- a/instances/experimentalApproach/epidemiology.jsonld
+++ b/instances/experimentalApproach/epidemiology.jsonld
@@ -11,5 +11,6 @@
   "name": "epidemiology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739400",
   "synonym": [
-    "epidemiological approach"]
+    "epidemiological approach"
+  ]
 }

--- a/instances/experimentalApproach/epidemiology.jsonld
+++ b/instances/experimentalApproach/epidemiology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739400",
   "knowledgeSpaceLink": null,
   "name": "epidemiology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739400",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Epidemiology",
   "synonym": [
     "epidemiological approach"
   ]

--- a/instances/experimentalApproach/epigenomics.jsonld
+++ b/instances/experimentalApproach/epigenomics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741207",
   "knowledgeSpaceLink": null,
   "name": "epigenomics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741207",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Epigenomics",
   "synonym": null
 }

--- a/instances/experimentalApproach/epigenomics.jsonld
+++ b/instances/experimentalApproach/epigenomics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on processes that modulate transcription but that do not directly alter the primary sequences of an organism's DNA.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741207",
   "knowledgeSpaceLink": null,
   "name": "epigenomics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741207",

--- a/instances/experimentalApproach/ethology.jsonld
+++ b/instances/experimentalApproach/ethology.jsonld
@@ -6,9 +6,10 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on natural unmanipulated human or animal behavior and social organization from a biological, life history, and often evolutionary perspective.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739388",
   "knowledgeSpaceLink": null,
   "name": "ethology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739388",
-  "synonym": null
+  "synonym": [
+    "ethological approach"]
 }

--- a/instances/experimentalApproach/ethology.jsonld
+++ b/instances/experimentalApproach/ethology.jsonld
@@ -11,5 +11,6 @@
   "name": "ethology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739388",
   "synonym": [
-    "ethological approach"]
+    "ethological approach"
+  ]
 }

--- a/instances/experimentalApproach/ethology.jsonld
+++ b/instances/experimentalApproach/ethology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739388",
   "knowledgeSpaceLink": null,
   "name": "ethology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739388",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Ethology",
   "synonym": [
     "ethological approach"
   ]

--- a/instances/experimentalApproach/evolutionaryBiology.jsonld
+++ b/instances/experimentalApproach/evolutionaryBiology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739392",
   "knowledgeSpaceLink": null,
   "name": "evolutionary biology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739392",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Evolution",
   "synonym": [
     "evolutionary approach"
   ]

--- a/instances/experimentalApproach/evolutionaryBiology.jsonld
+++ b/instances/experimentalApproach/evolutionaryBiology.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on heritable characteristics of biological populations and their variation through the modification of developmental process to produce new forms and species.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739392",
   "knowledgeSpaceLink": null,
   "name": "evolutionary biology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739392",
-  "synonym": null
+  "synonym": [
+    "evolutionary approach"
+  ]
 }

--- a/instances/experimentalApproach/expression.jsonld
+++ b/instances/experimentalApproach/expression.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739397",
   "knowledgeSpaceLink": null,
   "name": "expression",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739397",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Expression",
   "synonym": [
     "molecular expression approach"
   ]

--- a/instances/experimentalApproach/expression.jsonld
+++ b/instances/experimentalApproach/expression.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on driving or detecting expression of genes in cells or tissues.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739397",
   "knowledgeSpaceLink": null,
   "name": "expression",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739397",
-  "synonym": null
+  "synonym": [
+    "molecular expression approach"
+  ]
 }

--- a/instances/experimentalApproach/expressionCharacterization.jsonld
+++ b/instances/experimentalApproach/expressionCharacterization.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the cellular, anatomical, or morphological distribution of gene expression.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739409",
   "knowledgeSpaceLink": null,
   "name": "expression characterization",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739409",

--- a/instances/experimentalApproach/expressionCharacterization.jsonld
+++ b/instances/experimentalApproach/expressionCharacterization.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739409",
   "knowledgeSpaceLink": null,
   "name": "expression characterization",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739409",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/ExpressionCharachterization",
   "synonym": null
 }

--- a/instances/experimentalApproach/genetics.jsonld
+++ b/instances/experimentalApproach/genetics.jsonld
@@ -6,12 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Experimental approach that measures or manipulates some aspect of the genetic material of an organism.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/ilx_0104598",
+  "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "genetics",
-  "preferredOntologyIdentifier": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_100628",
-  "synonym": [
-    "heredity",
-    "genes"
-  ]
+  "preferredOntologyIdentifier": null,
+  "synonym": null
 }

--- a/instances/experimentalApproach/genetics.jsonld
+++ b/instances/experimentalApproach/genetics.jsonld
@@ -6,9 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Experimental approach that measures or manipulates some aspect of the genetic material of an organism.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0104598",
   "knowledgeSpaceLink": null,
   "name": "genetics",
-  "preferredOntologyIdentifier": null,
+  "preferredOntologyIdentifier": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_100628",
   "synonym": null
 }

--- a/instances/experimentalApproach/genetics.jsonld
+++ b/instances/experimentalApproach/genetics.jsonld
@@ -10,5 +10,8 @@
   "knowledgeSpaceLink": null,
   "name": "genetics",
   "preferredOntologyIdentifier": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_100628",
-  "synonym": null
+  "synonym": [
+    "heredity",
+    "genes"
+  ]
 }

--- a/instances/experimentalApproach/genomics.jsonld
+++ b/instances/experimentalApproach/genomics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on structure, function, evolution, and mapping of genomes, the entiretiy of the genetic material of a single organism.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741204",
   "knowledgeSpaceLink": null,
   "name": "genomics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741204",

--- a/instances/experimentalApproach/genomics.jsonld
+++ b/instances/experimentalApproach/genomics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741204",
   "knowledgeSpaceLink": null,
   "name": "genomics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741204",
+  "preferredOntologyIdentifier": "	http://uri.interlex.org/tgbugs/uris/readable/modality/Genomics",
   "synonym": null
 }

--- a/instances/experimentalApproach/histology.jsonld
+++ b/instances/experimentalApproach/histology.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on structure of biological tissue.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739399",
   "knowledgeSpaceLink": null,
   "name": "histology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739399",
-  "synonym": null
+  "synonym": [
+    "histological approach"
+  ]
 }

--- a/instances/experimentalApproach/histology.jsonld
+++ b/instances/experimentalApproach/histology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739399",
   "knowledgeSpaceLink": null,
   "name": "histology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739399",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Histology",
   "synonym": [
     "histological approach"
   ]

--- a/instances/experimentalApproach/informatics.jsonld
+++ b/instances/experimentalApproach/informatics.jsonld
@@ -6,13 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on collection, classification, storage, retrieval, analysis, visualization, and dissemination of recorded knowledge in computational systems.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/ilx_0105471",
+  "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "informatics",
-  "preferredOntologyIdentifier": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_100631",
-  "synonym": [
-    "information management",
-    "knowledge management",
-    "information science"
-  ]
+  "preferredOntologyIdentifier": null,
+  "synonym": null
 }

--- a/instances/experimentalApproach/informatics.jsonld
+++ b/instances/experimentalApproach/informatics.jsonld
@@ -6,9 +6,13 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on collection, classification, storage, retrieval, analysis, visualization, and dissemination of recorded knowledge in computational systems.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0105471",
   "knowledgeSpaceLink": null,
   "name": "informatics",
-  "preferredOntologyIdentifier": null,
-  "synonym": null
+  "preferredOntologyIdentifier": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_100631",
+  "synonym": [
+    "information management",
+    "knowledge management",
+    "information science"
+  ]
 }

--- a/instances/experimentalApproach/metabolomics.jsonld
+++ b/instances/experimentalApproach/metabolomics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on chemical processes involving metabolites, the small molecule substrates, intermediates and products of cell metabolism.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741203",
   "knowledgeSpaceLink": null,
   "name": "metabolomics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741203",

--- a/instances/experimentalApproach/metabolomics.jsonld
+++ b/instances/experimentalApproach/metabolomics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741203",
   "knowledgeSpaceLink": null,
   "name": "metabolomics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741203",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Metabolomics",
   "synonym": null
 }

--- a/instances/experimentalApproach/microscopy.jsonld
+++ b/instances/experimentalApproach/microscopy.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739404",
   "knowledgeSpaceLink": null,
   "name": "microscopy",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739404",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Microscopy",
   "synonym": null
 }

--- a/instances/experimentalApproach/microscopy.jsonld
+++ b/instances/experimentalApproach/microscopy.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on using differential contrast of microscopic structures to form an image.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739404",
   "knowledgeSpaceLink": null,
   "name": "microscopy",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739404",

--- a/instances/experimentalApproach/morphology.jsonld
+++ b/instances/experimentalApproach/morphology.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the shape and structure of living organisms or their parts.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739403",
   "knowledgeSpaceLink": null,
   "name": "morphology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739403",
-  "synonym": null
+  "synonym": [
+    "morphological approach"
+  ]
 }

--- a/instances/experimentalApproach/morphology.jsonld
+++ b/instances/experimentalApproach/morphology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739403",
   "knowledgeSpaceLink": null,
   "name": "morphology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739403",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Morphology",
   "synonym": [
     "morphological approach"
   ]

--- a/instances/experimentalApproach/multimodalResearch.jsonld
+++ b/instances/experimentalApproach/multimodalResearch.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739395",
   "knowledgeSpaceLink": null,
   "name": "multimodal research",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739395",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Multimodal",
   "synonym": [
     "multimodal approach"
   ]

--- a/instances/experimentalApproach/multimodalResearch.jsonld
+++ b/instances/experimentalApproach/multimodalResearch.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach that employs multiple experimental approaches in significant ways.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739395",
   "knowledgeSpaceLink": null,
   "name": "multimodal research",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739395",
-  "synonym": null
+  "synonym": [
+    "multimodal approach"
+  ]
 }

--- a/instances/experimentalApproach/multiomics.jsonld
+++ b/instances/experimentalApproach/multiomics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach that employs multiple omics approaches in significant ways.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739407",
   "knowledgeSpaceLink": null,
   "name": "multiomics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739407",

--- a/instances/experimentalApproach/multiomics.jsonld
+++ b/instances/experimentalApproach/multiomics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739407",
   "knowledgeSpaceLink": null,
   "name": "multiomics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739407",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Multiomics",
   "synonym": null
 }

--- a/instances/experimentalApproach/neuralConnectivity.jsonld
+++ b/instances/experimentalApproach/neuralConnectivity.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on functional or anatomical connections between single neurons or populations of neurons in defined anatomical regions.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739393",
   "knowledgeSpaceLink": null,
   "name": "neural connectivity",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739393",

--- a/instances/experimentalApproach/neuralConnectivity.jsonld
+++ b/instances/experimentalApproach/neuralConnectivity.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739393",
   "knowledgeSpaceLink": null,
   "name": "neural connectivity",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739393",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Connectivity",
   "synonym": null
 }

--- a/instances/experimentalApproach/neuroimaging.jsonld
+++ b/instances/experimentalApproach/neuroimaging.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741206",
   "knowledgeSpaceLink": null,
   "name": "neuroimaging",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741206",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Neuroimaging",
   "synonym": null
 }

--- a/instances/experimentalApproach/neuroimaging.jsonld
+++ b/instances/experimentalApproach/neuroimaging.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the non-invasive direct or indirect imaging of the structure, function, or pharmacology of the nervous system.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741206",
   "knowledgeSpaceLink": null,
   "name": "neuroimaging",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741206",

--- a/instances/experimentalApproach/omics.jsonld
+++ b/instances/experimentalApproach/omics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739405",
   "knowledgeSpaceLink": null,
   "name": "omics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739405",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Omics",
   "synonym": null
 }

--- a/instances/experimentalApproach/omics.jsonld
+++ b/instances/experimentalApproach/omics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on characterization and quantification of biological molecules that give rise to the structure, function, and dynamics of organisms or their parts.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739405",
   "knowledgeSpaceLink": null,
   "name": "omics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739405",

--- a/instances/experimentalApproach/optogenetics.jsonld
+++ b/instances/experimentalApproach/optogenetics.jsonld
@@ -6,9 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on using genetically encoded light-sensitive proteins in combination with targeted delivery of light in order to manipulate the behavior of populations of cells.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/ilx_0737732",
   "knowledgeSpaceLink": null,
   "name": "optogenetics",
-  "preferredOntologyIdentifier": null,
+  "preferredOntologyIdentifier": "http://id.nlm.nih.gov/mesh/2018/M0562437",
   "synonym": null
 }

--- a/instances/experimentalApproach/optogenetics.jsonld
+++ b/instances/experimentalApproach/optogenetics.jsonld
@@ -6,9 +6,9 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on using genetically encoded light-sensitive proteins in combination with targeted delivery of light in order to manipulate the behavior of populations of cells.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/ilx_0737732",
+  "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "optogenetics",
-  "preferredOntologyIdentifier": "http://id.nlm.nih.gov/mesh/2018/M0562437",
+  "preferredOntologyIdentifier": null,
   "synonym": null
 }

--- a/instances/experimentalApproach/physiology.jsonld
+++ b/instances/experimentalApproach/physiology.jsonld
@@ -6,9 +6,11 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on normal functions of living organisms and their parts.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739410",
   "knowledgeSpaceLink": null,
   "name": "physiology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739410",
-  "synonym": null
+  "synonym": [
+    "physiological approach"
+  ]
 }

--- a/instances/experimentalApproach/physiology.jsonld
+++ b/instances/experimentalApproach/physiology.jsonld
@@ -9,7 +9,7 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739410",
   "knowledgeSpaceLink": null,
   "name": "physiology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739410",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Physiology",
   "synonym": [
     "physiological approach"
   ]

--- a/instances/experimentalApproach/proteomics.jsonld
+++ b/instances/experimentalApproach/proteomics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741205",
   "knowledgeSpaceLink": null,
   "name": "proteomics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741205",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Proteomics",
   "synonym": null
 }

--- a/instances/experimentalApproach/proteomics.jsonld
+++ b/instances/experimentalApproach/proteomics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the composition, structure, and activity of an entire set of proteins in organisms or their parts.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741205",
   "knowledgeSpaceLink": null,
   "name": "proteomics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0741205",

--- a/instances/experimentalApproach/radiology.jsonld
+++ b/instances/experimentalApproach/radiology.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on using non-invasive techniques that use intrinsic or induced contrast to form images. Also covers purely clinical domains such as nuclear medicine.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739390",
   "knowledgeSpaceLink": null,
   "name": "radiology",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739390",

--- a/instances/experimentalApproach/radiology.jsonld
+++ b/instances/experimentalApproach/radiology.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739390",
   "knowledgeSpaceLink": null,
   "name": "radiology",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739390",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Radiology",
   "synonym": null
 }

--- a/instances/experimentalApproach/spatialTranscriptomics.jsonld
+++ b/instances/experimentalApproach/spatialTranscriptomics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on mapping the spatial location of gene activity in biological tissue.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739396",
   "knowledgeSpaceLink": null,
   "name": "spatial transcriptomics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739396",

--- a/instances/experimentalApproach/spatialTranscriptomics.jsonld
+++ b/instances/experimentalApproach/spatialTranscriptomics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739396",
   "knowledgeSpaceLink": null,
   "name": "spatial transcriptomics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739396",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/SpatialTranscriptomics",
   "synonym": null
 }

--- a/instances/experimentalApproach/transcriptomics.jsonld
+++ b/instances/experimentalApproach/transcriptomics.jsonld
@@ -9,6 +9,6 @@
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739406",
   "knowledgeSpaceLink": null,
   "name": "transcriptomics",
-  "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739406",
+  "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Transcriptomics",
   "synonym": null
 }

--- a/instances/experimentalApproach/transcriptomics.jsonld
+++ b/instances/experimentalApproach/transcriptomics.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
   "definition": "Any experimental approach focused on the transcriptome (all RNA transcripts) of one or more cells, tissues, or organisms.",
   "description": null,
-  "interlexIdentifier": null,
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739406",
   "knowledgeSpaceLink": null,
   "name": "transcriptomics",
   "preferredOntologyIdentifier": "http://uri.interlex.org/base/ilx_0739406",


### PR DESCRIPTION
All approaches have an InterLex ID now. A few comments/questions for @lzehl and @tgbugs:

1) I couldn't find "chemogenetics". Does this exist yet?

2) "genetics" and "informatics" are listed under "scientific discipline" in InterLex. Will those get a new/updated entry or is this was we should use here?

3) "optogenetics" exists twice (http://uri.interlex.org/ilx_0108079 &  http://uri.interlex.org/ilx_0737732). Definitions were rather similar, so I just picked one. Any objections? 

4) The "preferred ID" was the InterLex ID. So I copied the same one in for the "interlexID" as well. In almost all cases this was the preferred ID according to the InterLex entry. @lzehl if you don't want this repetition, we can remove them from the preferred ID again.